### PR TITLE
Fix/multiple title and description tags

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -43,6 +43,7 @@ plugins:
   - jekyll-feed
   - jekyll-sitemap
   - jekyll-gzip
+  - jekyll-seo-tag
 
 gzip:
   extensions:

--- a/src/js-libraries-and-framework.md
+++ b/src/js-libraries-and-framework.md
@@ -13,5 +13,5 @@ permalink: js-libraries-and-framework.html
 - [React.js](https://www.taniarascia.com/getting-started-with-react/)
 - [Angular](https://angular.tw/guide/ajs-quick-reference)
 - [Express.js](https://lighthouse.alphacamp.co/courses/23/units/3969)
-- [Vue.js](https://cn.vuejs.org/v2/guide/)
+- [Vue.js](https://v2.cn.vuejs.org/)
 - Angular.js


### PR DESCRIPTION
- 在 `_config.yml` 裡面 plugins 沒有將 `jekyll-seo-tag`加進去
所以在頁面上會同時跑出兩個 title 
- 修改 Vue.js url ，官網換網址了